### PR TITLE
use from_str rather than from_static HeaderName and HeaderValue

### DIFF
--- a/src/execution.rs
+++ b/src/execution.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::benchmark::BenchmarkResult;
 use crate::settings::{Operation, Settings};
 use anyhow::{Context, Result};
@@ -62,8 +64,8 @@ async fn exec(
                 let name = h.key.as_str();
                 let value = h.value.as_str();
 
-                let name = HeaderName::from_static(name);
-                let value = HeaderValue::from_static(value);
+                let name = HeaderName::from_str(name).unwrap();
+                let value = HeaderValue::from_str(value).unwrap();
                 headers_map.insert(name, value);
             });
             headers_map


### PR DESCRIPTION
This solves to me the following error when running cargo buil

```
error[E0521]: borrowed data escapes outside of function
  --> src/execution.rs:65:28
   |
41 |     settings: &Settings,
   |     --------  - let's call the lifetime of this reference `'1`
   |     |
   |     `settings` is a reference that is only valid in the function body
...
65 |                 let name = HeaderName::from_static(name);
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |                            |
   |                            `settings` escapes the function body here
   |                            argument requires that `'1` must outlive `'static`

For more information about this error, try `rustc --explain E0521`.
error: could not compile `goku` due to previous error
```