### PR TITLE
Support more recent Linux versions and arch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,22 @@ jobs:
           - os-name: Linux-x86_64
             runs-on: ubuntu-20.04
             target: x86_64-unknown-linux-musl
+          
+          - os-name: Linux-x86_64
+            runs-on: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+          
+          - os-name: Linux-x86_64
+            runs-on: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+          
+          - os-name: Linux-arm64
+            runs-on: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-musl
+          
+          - os-name: Linux-arm64
+            runs-on: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
 
           - os-name: Windows-x86_64
             runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.2
       - name: Build binary
-        uses: houseabsolute/actions-rust-cross@v0.0.15
+        uses: houseabsolute/actions-rust-cross@v1
         with:
           command: "build"
           target: ${{ matrix.platform.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,22 @@ jobs:
           - os-name: Linux-x86_64
             runs-on: ubuntu-20.04
             target: x86_64-unknown-linux-musl
+          
+          - os-name: Linux-x86_64
+            runs-on: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+          
+          - os-name: Linux-x86_64
+            runs-on: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+          
+          - os-name: Linux-arm64
+            runs-on: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-musl
+          
+          - os-name: Linux-arm64
+            runs-on: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
 
           - os-name: Windows-x86_64
             runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,14 +45,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.2
       - name: Build binary
-        uses: houseabsolute/actions-rust-cross@v0.0.15
+        uses: houseabsolute/actions-rust-cross@v1
         with:
           command: "build"
           target: ${{ matrix.platform.target }}
           args: "--locked --release"
           strip: true
       - name: Publish artifacts and release
-        uses: houseabsolute/actions-rust-release@v0.0.2
+        uses: houseabsolute/actions-rust-release@v0.0.5
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
         with:


### PR DESCRIPTION
Hi, Github recently released [support for ARM-based runner for public repositories](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) so I thought `goku` might as well benefit from it too. While I was at it, I also bumped actions version.